### PR TITLE
add_nameCount commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Ignore unnecessary files and directories
+**\HELP.md
+**\.apt_generated
+**\.classpath
+**\.factorypath
+**\.project
+**\.settings
+**\.springBeans
+**\.sts4-cache
+**\.idea
+**\*.iws
+**\*.iml
+**\*.ipr
+**nbproject\private
+**nbbuild
+**dist
+**nbdist
+**.nb-gradle
+**\build
+**\.vscode
+
+# Ignore default IntelliJ IDEA and VS Code files
+.idea\shelf
+.idea\workspace.xml
+.idea\dataSources
+.idea\dataSources.local.xml
+.idea\httpRequests

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official OpenJDK runtime as a parent image
+FROM openjdk:17-jdk-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the jar file into the container
+COPY target/pet_name-0.0.1-SNAPSHOT.jar app.jar
+
+# Copy the SQLite database file
+COPY database/pets_database.db /app/database/pets_database.db
+
+# Expose the port
+EXPOSE 9092
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for paws-and-names on 2024-08-19T13:27:07+09:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'paws-and-names'
+primary_region = 'nrt'
+
+[build]
+
+[http_service]
+  internal_port = 9092
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/src/main/java/com/project/pet_name/controller/PetController.java
+++ b/src/main/java/com/project/pet_name/controller/PetController.java
@@ -59,7 +59,7 @@ public class PetController {
 
 
 
-    @GetMapping("/main")
+    @GetMapping("/")
     public String mainPage() {
         return "main";
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,10 @@
 server:
   port: 9092
+  address: 0.0.0.0
 
 spring:
   datasource:
-    url: jdbc:sqlite:C:/Project/pet_name/database/pets_database.db
+    url: jdbc:sqlite:database/pets_database.db
     driver-class-name: org.sqlite.JDBC
     username: ""
     password: ""

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -52,6 +52,53 @@ nav a:hover {
     font-family: 'Montserrat', sans-serif;
 }
 
+
+/* 순위, 성별, 이름, 개수 레이블 스타일 */
+.ranking-header {
+    display: flex;
+    align-items: center;
+    padding: 10px 15px;
+    font-weight: bold;
+    border-radius: 5px 5px 0 0; /* 상단 모서리 둥글게 */
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1); /* 그림자 효과 */
+    margin-bottom: 10px; /* 항목과의 여백 */
+}
+
+.header-rank,
+.header-name,
+.header-count {
+    font-size: 1.2em;
+    flex: 1;
+}
+
+.header-rank {
+    width: 30px; /* 순위 열의 너비 */
+    flex: 0.45;
+}
+
+/* 모바일 화면 전용 스타일 */
+@media (max-width: 767px) { /* 768px 미만인 경우, 모바일 화면에 해당 */
+    .header-rank {
+        width: 30px; /* 순위 열의 너비 */
+        flex: 1.2;
+    }
+}
+
+.header-gender {
+    width: 50px; /* 성별 아이콘 열의 너비 */
+}
+
+.header-name {
+    flex: 2;
+    text-align: left; /* 이름을 왼쪽 정렬 */
+    margin-right: 10px; /* 오른쪽 여백 추가 */
+}
+
+.header-count {
+    width: 80px; /* 개수 열의 너비 */
+    text-align: right; /* 개수를 오른쪽 정렬 */
+}
+
 .ranking-list {
     display: flex;
     flex-direction: column;
@@ -60,23 +107,23 @@ nav a:hover {
 
 .ranking-item {
     display: flex;
-    justify-content: space-between;
+    align-items: center;
     padding: 10px 15px;
     background-color: #f9f9f9;
     border-radius: 5px;
-    align-items: center;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
 .rank {
     font-size: 1.2em;
     font-weight: bold;
-    width: 40px;
+    width: 50px; /* 순위 영역의 너비 */
+    text-align: center;
 }
 
 .gender {
     font-size: 1.2em;
-    width: 50px;
+    width: 50px; /* 성별 아이콘 영역의 너비 */
     text-align: center;
 }
 
@@ -88,12 +135,25 @@ nav a:hover {
     color: #ff69b4; /* 핑크색 */
 }
 
-.name {
-    font-size: 1.2em;
-    flex-grow: 1;
-    font-family: "Kanit", sans-serif; /* 귀엽고 사각사각한 폰트 */
+.item-container {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    justify-content: space-between; /* 이름과 숫자를 오른쪽 끝으로 정렬 */
 }
 
+.name {
+    font-size: 1.2em;
+    font-family: 'Kanit', sans-serif; /* 귀엽고 사각사각한 폰트 */
+    margin-right: 5px; /* 이름과 숫자 사이의 여백 */
+}
+
+.name-count {
+    font-size: 1em;
+    color: #888;
+}
+
+/* 버튼 스타일 */
 .load-more-btn {
     display: block;
     width: 100%;
@@ -110,7 +170,6 @@ nav a:hover {
 .load-more-btn:hover {
     background-color: #d89e1a; /* 버튼 호버 색상 */
 }
-
 
 /* 이름 생성 페이지 스타일 */
 .generator-container {
@@ -198,7 +257,6 @@ footer a {
 footer a:hover {
     text-decoration: underline;
 }
-
 
 .loading {
     text-align: center;

--- a/src/main/resources/static/js/main-page.js
+++ b/src/main/resources/static/js/main-page.js
@@ -2,6 +2,11 @@ let page = 0;
 let isLoading = false;
 let genderFilterValue = ''; // 초기 상태는 모든 성별
 
+
+function formatNumber(number) {
+    return number.toLocaleString(); // 숫자를 천 단위로 구분하여 문자열로 반환
+}
+
 function loadMorePets() {
     if (isLoading) return;
     isLoading = true;
@@ -33,9 +38,20 @@ function loadMorePets() {
                 name.className = 'name';
                 name.textContent = pet.animalName || 'No Name';
 
+                // 이름 옆에 숫자를 추가
+                const nameCount = document.createElement('div');
+                nameCount.className = 'name-count';
+                nameCount.textContent = pet.nameCount ? `${formatNumber(pet.nameCount)}` : '';
+
+                // 모든 항목을 하나의 컨테이너에 넣기
+                const itemContainer = document.createElement('div');
+                itemContainer.className = 'item-container';
+                itemContainer.appendChild(name);
+                itemContainer.appendChild(nameCount);
+
                 rankingItem.appendChild(rank);
                 rankingItem.appendChild(gender);
-                rankingItem.appendChild(name);
+                rankingItem.appendChild(itemContainer);
 
                 rankingList.appendChild(rankingItem);
             });

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -10,7 +10,7 @@
 <header>
     <h1>Paws & Names</h1>
     <nav>
-        <a href="/main">Top Ranking</a>
+        <a href="/">Top Ranking</a>
         <a href="/random-name">Random Generator</a>
     </nav>
 </header>
@@ -24,6 +24,14 @@
         <button id="maleButton">Male</button>
         <button id="femaleButton">Female</button>
     </div>
+
+    <!-- 열 제목 추가 -->
+    <div class="ranking-header">
+        <div class="header-rank">Rank</div>
+        <div class="header-name">Name</div>
+        <div class="header-count">Count</div>
+    </div>
+
 
     <div id="ranking-list" class="ranking-list">
         <!-- 이곳에 JS로 데이터가 추가됩니다 -->

--- a/src/main/resources/templates/random.html
+++ b/src/main/resources/templates/random.html
@@ -10,7 +10,7 @@
 <header>
     <h1>Paws & Names</h1>
     <nav>
-        <a href="/main">Top Ranking</a>
+        <a href="/">Top Ranking</a>
         <a href="/random-name">Random Generator</a>
     </nav>
 </header>


### PR DESCRIPTION
## Description

이 PR은 애플리케이션에 몇 가지 주요 업데이트를 추가합니다. 주요 목표는 사용자에게 순위, 이름, 개수 정보가 명확하게 표시되도록 개선하는 것입니다.

### Changes

- **기능 구현:**
  - `ranking-header`를 추가하여 순위, 이름, 개수를 표시하는 열 제목을 추가했습니다.
  - `name-count` 클래스를 추가하여 이름 옆에 개수를 표시했습니다.
  - `formatNumber` 함수를 추가하여 숫자를 천 단위로 구분하는 기능을 구현했습니다.

- **스타일 개선:**
  - `styles.css`에 `ranking-header`와 관련된 스타일을 추가하여 열 제목의 레이아웃을 정의했습니다.
  - `main-page.js`에 숫자를 천 단위로 구분하는 `formatNumber` 함수를 추가했습니다.

### Related Issues

- 없음

### Changed Behavior

- `ranking-header`를 사용하여 순위, 이름, 개수의 열 제목을 명확히 표시합니다.
- `name-count`를 사용하여 각 이름 옆에 개수를 추가했습니다. 개수는 천 단위로 구분되어 표시됩니다.

### Testing Instructions

- **단계별 테스트:**
  1. 페이지를 열어 `ranking-header`와 `ranking-list`가 올바르게 표시되는지 확인합니다.
  2. `Load More` 버튼을 클릭하여 추가 데이터를 로드하고, 이름 옆에 개수가 올바르게 표시되는지 확인합니다.
  3. 개수가 천 단위로 쉼표로 구분되는지 확인합니다.

### Additional Information

- 새로 추가된 CSS 및 JavaScript 코드는 열 제목과 데이터 표시를 보다 직관적으로 만듭니다.
- 숫자를 천 단위로 구분하여 사용자에게 더 나은 가독성을 제공합니다.
